### PR TITLE
Fix ENABLE_UNSAFE_LOCATIONS build flag

### DIFF
--- a/cmake/developer_package/download/download_and_extract.cmake
+++ b/cmake/developer_package/download/download_and_extract.cmake
@@ -124,6 +124,8 @@ function (DownloadOrExtractInternal URL archive_path unpacked_path folder fattal
         if (${result})
           set (downloadStatus "OK")
         endif()
+      else()
+        set (downloadStatus "OK")
       endif()
     else()
       debug_message("archive found on FS : ${archive_path}, however we cannot check it's checksum and think that it is invalid")


### PR DESCRIPTION
Previously, the ENABLE_UNSAFE_LOCATIONS flag did not work properly because even if the archive existed on disk and could be extracted, the download status was never set to OK so the script stopped.

This patch fixes that issue, and enables openvino to be built in scenarios where Internet access is not available at build time.